### PR TITLE
div_container_margin_top_create

### DIFF
--- a/c4c_cup_single/login.css
+++ b/c4c_cup_single/login.css
@@ -1,4 +1,7 @@
 .container {
+  /* divタグのクラス「container」（ブロック要素）を中央揃えにする */
   text-align: center;
-  margin:0 auto;
+  /* ブロック要素内の上部marigin（余白）を指定する */
+  margin-top: 3%;
+  background-color: bisque;
 }

--- a/c4c_cup_single/login.html
+++ b/c4c_cup_single/login.html
@@ -5,6 +5,8 @@
   <title>LoginScreen</title>
 </head>
 <body>
+  <!-- divタグを親要素、h2タグを子要素とする -->
+  <!-- divタグ、h2タグ両方にクラスを割り当て汎用的にCSSを適用できるようにする -->
   <div class="container">
     <h2 class="main_title">ログイン画面</h2>
   </div>


### PR DESCRIPTION
### C4C杯_ログイン画面タイトル_上部余白調整（プロトタイプ）
- `html、css`両方に記述したコードにコメント追記
- divタグのcontainerクラス（ブロック要素）を中央に位置させた状態で、`margin_top`を割り当て上部余白を3%適用