### PR TITLE
mail_input_center

### DIFF
--- a/c4c_cup_single/login.css
+++ b/c4c_cup_single/login.css
@@ -5,3 +5,29 @@
   margin-top: 3%;
   background-color: bisque;
 }
+
+.mail_field {
+  /* 親要素のdivタグを中央揃えにする */
+  text-align: center;
+  /* 上部marigin（余白）を指定する */
+  margin-top: 30%;
+  background-color: powderblue;
+}
+
+.mail_text {
+  /* 子要素をインラインブロック要素として、左揃えに指定する */
+  text-align: left;
+  display: inline-block;
+}
+
+.password_field {
+  /* 中央揃えにする */
+  text-align: center;
+  background-color: lightpink;
+}
+
+.password_text {
+  /* 子要素をインラインブロック要素として、左揃えに指定する */
+  text-align: left;
+  display: inline-block;
+}

--- a/c4c_cup_single/login.html
+++ b/c4c_cup_single/login.html
@@ -10,12 +10,19 @@
   <div class="container">
     <h2 class="main_title">ログイン画面</h2>
   </div>
-  <div class="mail_text">
-    <p>メールアドレス（ログインID）</p>
-      <input type="text" name="user_id" size="40" maxlength="30">
-    <p>パスワード</p>
-      <input type="password" name="user_pwd" size="40" maxlength="30"
-    <input type="text">
+  <!-- メール入力欄を2つのdivタグで囲み、親要素、子要素とする -->
+  <div class="mail_field">
+    <div class="mail_text">
+      <p>メールアドレス（ログインID）</p>
+        <input type="text" name="user_id" size="40" maxlength="30">
+    </div>
+  </div>
+  <!-- パスワード入力欄を2つのdivタグで囲み、親要素、子要素とする -->
+  <div class="password_field">
+    <div class="password_text">
+      <p>パスワード</p>
+      <input type="password" name="user_pwd" size="40" maxlength="30">
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
### C4C杯_ログイン画面_メールアドレス、パスワードテキスト作成（プロトタイプ）
- login.htmlのメール入力欄を2つのdivタグ`div class="mail_field"` `div class="mail_text"`で囲み、親要素、子要素とする 
- login.htmlのパスワード入力欄を2つのdivタグ`div class="password_field"` `div class="passwprd_text"`で囲み、親要素、子要素とする 
- login.htmlで割り当てた上記divタグの親要素に、login.cssで`text-align: center;`とし中央揃えにし、子要素に`display: inline-block;` `text-align: left;`子要素をインラインブロック要素として、左揃えに指定する