### PR TITLE
password_none_link_create

### DIFF
--- a/c4c_cup_single/login.css
+++ b/c4c_cup_single/login.css
@@ -20,6 +20,11 @@
   display: inline-block;
 }
 
+/* pタグの下部marigin（余白）をなくし入力欄の幅を寄せる */
+.mail_text p {
+  margin-bottom: 0px;
+}
+
 .password_field {
   /* 親要素のdivタグを中央揃えにする */
   text-align: center;
@@ -30,6 +35,11 @@
   /* 子要素をインラインブロック要素として、左揃えに指定する */
   text-align: left;
   display: inline-block;
+}
+
+/* pタグの下部marigin（余白）をなくし入力欄の幅を寄せる */
+.password_text p {
+  margin-bottom: 0px;
 }
 
 /* ボタンの親要素のdivタグを中央揃えにすることで、子要素も中央揃えにする */
@@ -52,5 +62,12 @@
 .account_link {
   /* 親要素のdivタグを中央揃えにする */
   text-align: center;
-  margin-top: 2%;
+  margin-top: 1%;
+  background-color: lightgoldenrodyellow;
+}
+
+.password_link {
+  /* 親要素のdivタグを中央揃えにする */
+  text-align: center;
+  background-color: lightgoldenrodyellow;
 }

--- a/c4c_cup_single/login.html
+++ b/c4c_cup_single/login.html
@@ -5,32 +5,48 @@
   <title>LoginScreen</title>
 </head>
 <body>
+  <!-- ログイン画面テキスト作成 -->
   <!-- divタグを親要素、h2タグを子要素とする -->
   <!-- divタグ、h2タグ両方にクラスを割り当て汎用的にCSSを適用できるようにする -->
   <div class="container">
     <h2 class="main_title">ログイン画面</h2>
   </div>
-  <!-- メール入力欄を親要素、子要素、2つのdivタグで囲み、input type="text"でメールアドレス入力欄を作成 -->
+  
+  <!-- メール入力欄作成 -->
+  <!-- 親要素、子要素、2つのdivタグで囲み、input type="text"でメールアドレス入力欄を作成 -->
   <div class="mail_field">
     <div class="mail_text">
       <p>メールアドレス（ログインID）</p>
         <input type="text" name="user_id" size="40" maxlength="30">
     </div>
   </div>
-  <!-- パスワード入力欄を親要素、子要素、2つのdivタグで囲み、input type="password"でパスワード入力欄を作成 -->
+  
+  <!-- パスワード入力欄作成 -->
+  <!-- 親要素、子要素、2つのdivタグで囲み、input type="password"でパスワード入力欄を作成 -->
   <div class="password_field">
     <div class="password_text">
       <p>パスワード</p>
       <input type="password" name="user_pwd" size="40" maxlength="30">
     </div>
   </div>
+  
+  <!-- ログインボタン作成 -->
   <!-- 親要素をdivタグで囲み、子要素をaタグで別リンクへ遷移可能、クラスを割り当てCSSでボタンを作成できるようにする -->
   <div class="button_box">
     <a href="#" class="login_button">ログイン</a>
   </div>
+
+  <!-- アカウントなしリンク作成 -->
   <!-- 親要素をdivタグで囲み、子要素をaタグで別リンクへ遷移可能にする -->
   <div class="account_link">
     <a href="#">アカウントをお持ちでない方はこちら</a>
   </div>
+
+  <!-- パスワード忘れリンク作成 -->
+  <!-- 親要素をdivタグで囲み、子要素をaタグで別リンクへ遷移可能にする -->
+  <div class="password_link">
+    <a href="#">パスワードをお忘れの方はこちら</a>
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
### C4C杯_ログイン画面_ログインボタン作成（プロトタイプ）
- login.html
1  divタグ`div class="password_link"` 親要素とする 
2  子要素のaタグ`a href="#"`で別リンクへ遷移可能できるように指定
- login.css
1  親要素`password_link`を`text-align: center;`とし中央揃えにする

- 備考（修正）
メールアドレス、パスワード入力欄を`.mail_text p {margin-bottom: 0px;`として、pタグ下部marigin（余白）をなくし入力欄の幅を寄せた
